### PR TITLE
Support for wheel package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /src/c_tests/build_cmake_vs2015
 /dist
 /build
+/src/openvr.egg-info
 /MANIFEST
 /.project
 /.pydevproject

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 # Load module version from ovr/version.py
 exec(open('src/openvr/version.py').read())


### PR DESCRIPTION
I used to store my modules using the wheel format.
Using `setuptools` instead of `distutils.core` allows this, and should be backward compatible with other packaging methods.