### PR TITLE
Automatically determine size for VRControllerState_t

### DIFF
--- a/src/openvr/__init__.py
+++ b/src/openvr/__init__.py
@@ -2165,7 +2165,7 @@ class IVRSystem(object):
         result = fn(eEye, type_)
         return result
 
-    def getControllerState(self, unControllerDeviceIndex, unControllerStateSize):
+    def getControllerState(self, unControllerDeviceIndex, unControllerStateSize=sizeof(VRControllerState_t)):
         """
         Fills the supplied struct with the current state of the controller. Returns false if the controller index
         is invalid.
@@ -2176,7 +2176,7 @@ class IVRSystem(object):
         result = fn(unControllerDeviceIndex, byref(pControllerState), unControllerStateSize)
         return result, pControllerState
 
-    def getControllerStateWithPose(self, eOrigin, unControllerDeviceIndex, unControllerStateSize):
+    def getControllerStateWithPose(self, eOrigin, unControllerDeviceIndex, unControllerStateSize=sizeof(VRControllerState_t)):
         """
         fills the supplied struct with the current state of the controller and the provided pose with the pose of 
         the controller when the controller state was updated most recently. Use this form if you need a precise controller

--- a/src/translate/translate.pl
+++ b/src/translate/translate.pl
@@ -821,6 +821,14 @@ EOF
 
                     $fn_name = lcfirst($fn_name); # first character lower case for python functions
 
+                    # exception for size parameter in GetControllerState
+                    # openvr 1.0.4 added a `uint32_t unControllerStateSize` to  `getControllerState`
+                    # and `getControllerStateWithPose`. We default it to `sizeof(VRControllerState_t)`
+                    # see https://github.com/cmbruns/pyopenvr/issues/27 for details
+                    # fix by https://github.com/daniel5gh
+                    foreach (@call_arg_names) {
+                        $_ =~ s/(unControllerStateSize)/$1=sizeof(VRControllerState_t)/;
+                    }
                     print "    def $fn_name(";
                     print join ", ", @call_arg_names;
                     print "):\n";


### PR DESCRIPTION
This pull request adds logic to `translate.pl` so that generated bindings will automatically determine the size of the `VRControllerState_t` struct that is going to be filled by OpenVR native code in `getControllerStateWithPose` and `getControllerState`.

The bindings in `__init__.py` are re-generated and existing manual patching has been re-applied.

As detailed in https://github.com/cmbruns/pyopenvr/issues/27 binary versions of OpenVR prior to 1.0.4 on Linux and OSX had wrong struct packing. To accommodate for this version 1.0.4 introduced a size argument for said struct.