### PR TITLE
fix after removal of openvr.API_OpenGL from API

### DIFF
--- a/src/openvr/gl_renderer.py
+++ b/src/openvr/gl_renderer.py
@@ -98,7 +98,7 @@ class OpenVrFramebuffer(object):
             self.texture.handle = self.resolve_texture_id
         else:
             self.texture.handle = self.texture_id
-        self.texture.eType = openvr.API_OpenGL
+        self.texture.eType = openvr.TextureType_OpenGL
         self.texture.eColorSpace = openvr.ColorSpace_Gamma
         
     def submit(self, eye):
@@ -156,17 +156,15 @@ class OpenVrGlRenderer(list):
         zNear = 0.2
         zFar = 500.0
         self.projection_left = numpy.asarray(matrixForOpenVrMatrix(self.vr_system.getProjectionMatrix(
-                openvr.Eye_Left, 
-                zNear, zFar, 
-                openvr.API_OpenGL)))
+            openvr.Eye_Left,
+            zNear, zFar)))
         self.projection_right = numpy.asarray(matrixForOpenVrMatrix(self.vr_system.getProjectionMatrix(
-                openvr.Eye_Right, 
-                zNear, zFar, 
-                openvr.API_OpenGL)))
+            openvr.Eye_Right,
+            zNear, zFar)))
         self.view_left = matrixForOpenVrMatrix(
-                self.vr_system.getEyeToHeadTransform(openvr.Eye_Left)).I # head_X_eye in Kane notation
+            self.vr_system.getEyeToHeadTransform(openvr.Eye_Left)).I  # head_X_eye in Kane notation
         self.view_right = matrixForOpenVrMatrix(
-                self.vr_system.getEyeToHeadTransform(openvr.Eye_Right)).I # head_X_eye in Kane notation
+            self.vr_system.getEyeToHeadTransform(openvr.Eye_Right)).I  # head_X_eye in Kane notation
         for actor in self:
             actor.init_gl()
 


### PR DESCRIPTION
`openvr.API_OpenGL` has been removed.

This PR changes the `OpenVrGlRenderer` to use the new `openvr.TextureType_OpenGL` for the texture `eType` and removes the old enum from calls to `getProjectionMatrix`.