### PR TITLE
Patch to make reading the controller buttons work

### DIFF
--- a/src/openvr/__init__.py
+++ b/src/openvr/__init__.py
@@ -1426,13 +1426,23 @@ class VRControllerAxis_t(Structure):
     ]
 
 
-class VRControllerState_t(Structure):
-    _fields_ = [
-        ("unPacketNum", c_uint32),
-        ("ulButtonPressed", c_uint64),
-        ("ulButtonTouched", c_uint64),
-        ("rAxis", VRControllerAxis_t * 5),
-    ]
+if sizeof(c_void_p) != 4 and platform.system() == 'Linux':
+    class VRControllerState_t(Structure):
+        _pack_ = 4
+        _fields_ = [
+            ("unPacketNum", c_uint32),
+            ("ulButtonPressed", c_uint64),
+            ("ulButtonTouched", c_uint64),
+            ("rAxis", VRControllerAxis_t * 5),
+        ]
+else:
+    class VRControllerState_t(Structure):
+        _fields_ = [
+            ("unPacketNum", c_uint32),
+            ("ulButtonPressed", c_uint64),
+            ("ulButtonTouched", c_uint64),
+            ("rAxis", VRControllerAxis_t * 5),
+        ]
 
 
 class Compositor_OverlaySettings(Structure):


### PR DESCRIPTION
To workaround https://github.com/cmbruns/pyopenvr/issues/27 on my Ubuntu 16.04 64bits.

I admit it's ugly but it makes it work on my system.

Also, find a minimal example that prints all the controller events on the terminal:
https://gist.github.com/awesomebytes/75daab3adb62b331f21ecf3a03b3ab46

Even if it's not mergeable, I hope it helps someone to get this to work.