### PR TITLE
Add install and extra requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,25 @@ Intended Audience :: Developers
 License :: OSI Approved :: BSD License
 Operating System :: Microsoft :: Windows
 Operating System :: Microsoft :: Windows :: Windows 7
+Operating System :: Microsoft :: Windows :: Windows 10
 Operating System :: POSIX :: Linux
 Operating System :: MacOS :: MacOS X
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Multimedia :: Graphics :: 3D Rendering
 Topic :: Scientific/Engineering :: Visualization
 Development Status :: 4 - Beta
 """.splitlines(),
+    install_requires=[
+        'numpy',
+        'PyOpenGL',
+    ],
+    extras_require={
+        'glfw': ['glfw'],
+        'PyQt5': ['PyQt5'],
+        #'PySide': ['PySide'], # does not support past python 3.5
+        'wx': ['wxPython'],
+    }
 )


### PR DESCRIPTION
I have added `install_requires` which will provide dependencies for all installs and `extras_require` which should support installations that install extra dependencies.

So

* `pip install openvr` will install `openvr` and `numpy` and `PyOpenGL`, let me know if I've missed any global dependencies
* `pip install openvr[glwf]`  - installs `glwf`
* `pip install openvr[PyQt5]`  - installs `PyQt5`
* `pip install openvr[wx]`  - installs `wxPython`

I should probably add this info to the README ... also `PySide` seems dead, I can add it but not conditionally for older pythons (as far as I understand, maybe it is possible).  I don't have VR on linux handy to test SDL2, I would have added it if it appeared to be pip installable, but it didn't.  I haven't had a chance to verify, though I could.

Note I also add a couple classifiers.

refs #31 