### PR TITLE
fix: error not reported from getStringTrackedDeviceProperty

### DIFF
--- a/src/openvr/__init__.py
+++ b/src/openvr/__init__.py
@@ -3029,10 +3029,10 @@ class IVRSystem(object):
         fn = self.function_table.getStringTrackedDeviceProperty
         error = ETrackedPropertyError()
         bufferSize = fn(deviceIndex, prop, None, 0, byref(error))
-        if bufferSize == 0:
-            return ''
-        value = ctypes.create_string_buffer(bufferSize)
-        fn(deviceIndex, prop, value, bufferSize, byref(error))
+        if openvr.error_code.TrackedPropertyError.error_index[int(error.value)] \
+                == openvr.error_code.TrackedProp_BufferTooSmall:
+            value = ctypes.create_string_buffer(bufferSize)
+            fn(deviceIndex, prop, value, bufferSize, byref(error))
         openvr.error_code.TrackedPropertyError.check_error_value(error.value)
         return bytes(value.value).decode('utf-8')
 


### PR DESCRIPTION
In the original code, when the call to `IVRSystem::GetStringTrackedDeviceProperty` failed with error (e.g. "TrackedProp_UnknownProperty") but the returned buffer size was 0, the wrapper returned empty string, instead of signalling the error.

The fix first tests for "buffer too small" condition and only after dealing with that does the regular error code check.