### PR TITLE
Save error code in the exception instance.

### DIFF
--- a/src/openvr/__init__.py
+++ b/src/openvr/__init__.py
@@ -3042,7 +3042,7 @@ class IVRSystem(object):
         of the error enum value for all valid error codes
         """
         fn = self.function_table.getPropErrorNameFromEnum
-        result = fn(error)
+        result = fn(error).decode('utf-8')
         return result
 
     def pollNextEvent(self, event):

--- a/src/openvr/error_code/__init__.py
+++ b/src/openvr/error_code/__init__.py
@@ -20,7 +20,11 @@ class ErrorCode(OpenVRError):
         error_class = cls.error_index[int(error_value)]
         if not error_class.is_error:
             return
-        raise error_class(message)
+        raise error_class(error_value, message)
+
+    def __init__(this, error_value, message=''):
+        this.error_value = error_value
+        OpenVRError.__init__(this, message)
 
 
 class TrackedPropertyError(ErrorCode):


### PR DESCRIPTION
When the wrapper raised an exception it did not preserve the original error value. This made the error message resolution (e.g. by using `getPropErrorNameFromEnum`) a bit tricky.

This patch also fixes the return value of the function `getPropErrorNameFromEnum` (was `bytes`, now `string`).