### PR TITLE
Explicitly set m_nSize when constructing Compositor_FrameTiming

### DIFF
--- a/src/openvr/__init__.py
+++ b/src/openvr/__init__.py
@@ -2391,6 +2391,9 @@ class CameraVideoStreamFrameHeader_t(Structure):
 class Compositor_FrameTiming(Structure):
     """Provides a single frame's timing information to the app"""
 
+    def __init__(self):
+        super().__init__(m_nSize = sizeof(Compositor_FrameTiming))
+
     _fields_ = [
         ("m_nSize", c_uint32),
         ("m_nFrameIndex", c_uint32),


### PR DESCRIPTION
Fixed #97 to allow properly obtaining FrameTiming.